### PR TITLE
ci(adr-001): complexity-baseline regression guard — silent class downgrades fail CI

### DIFF
--- a/.github/complexity-baseline.txt
+++ b/.github/complexity-baseline.txt
@@ -1,6 +1,6 @@
+FindAnomalousRowsOp                                                                        ComplexityClass::Adaptive
+IncrementalSolveOp                                                                         ComplexityClass::Adaptive
 crate::optimized_solver::OptimizedConjugateGradientSolver                                  ComplexityClass::Linear
 crate::solver::neumann::NeumannSolver                                                      ComplexityClass::Linear
 crate::sublinear::johnson_lindenstrauss::JLEmbedding                                       ComplexityClass::Linear
 crate::sublinear::sublinear_neumann::SublinearNeumannSolver                                ComplexityClass::Adaptive
-FindAnomalousRowsOp                                                                        ComplexityClass::Adaptive
-IncrementalSolveOp                                                                         ComplexityClass::Adaptive

--- a/.github/complexity-baseline.txt
+++ b/.github/complexity-baseline.txt
@@ -1,0 +1,6 @@
+crate::optimized_solver::OptimizedConjugateGradientSolver                                  ComplexityClass::Linear
+crate::solver::neumann::NeumannSolver                                                      ComplexityClass::Linear
+crate::sublinear::johnson_lindenstrauss::JLEmbedding                                       ComplexityClass::Linear
+crate::sublinear::sublinear_neumann::SublinearNeumannSolver                                ComplexityClass::Adaptive
+FindAnomalousRowsOp                                                                        ComplexityClass::Adaptive
+IncrementalSolveOp                                                                         ComplexityClass::Adaptive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,31 @@ jobs:
       - name: cargo bench --bench solver_benchmarks (smoke)
         run: cargo bench --bench solver_benchmarks -- --quick
 
+  # ADR-001 item #1 + phase-2: regression-guard against silent
+  # complexity-class downgrades. A PR that changes a public solver
+  # from SubLinear → Linear (or any worse direction) fails CI unless
+  # the author updates `.github/complexity-baseline.txt` deliberately.
+  # That makes the type-level Complexity contract enforceable across
+  # PRs the same way the safe-path security tests are.
+  complexity-baseline-guard:
+    name: complexity baseline (no silent downgrades)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: regenerate baseline + diff against checked-in
+        run: |
+          scripts/extract_complexity_classes.sh > /tmp/current-baseline.txt
+          if ! diff -u .github/complexity-baseline.txt /tmp/current-baseline.txt; then
+            echo "::error::Complexity-class baseline drifted. \
+            A solver's CLASS changed without an accompanying update to \
+            .github/complexity-baseline.txt. If this is intentional, \
+            regenerate the baseline:"
+            echo "   scripts/extract_complexity_classes.sh > .github/complexity-baseline.txt"
+            echo "and include the diff in your PR. See ADR-001 for context."
+            exit 1
+          fi
+          echo "Complexity baseline matches checked-in snapshot."
+
   # ADR-001 §SOTA: closes the last gap by exercising the
   # joules_per_decision example on every PR. GH Actions doesn't expose
   # per-job power counters (no RAPL access), so the run uses the

--- a/scripts/extract_complexity_classes.sh
+++ b/scripts/extract_complexity_classes.sh
@@ -18,6 +18,13 @@
 
 set -euo pipefail
 
+# Force C locale so the final `sort -u` produces byte-stable output
+# across hosts (otherwise locale-aware sort orders uppercase before
+# lowercase on Linux CI but the opposite on macOS / glibc-with-UTF-8).
+# Without this, the complexity-baseline-guard CI job fails on PRs
+# generated from a different locale than the baseline.
+export LC_ALL=C
+
 cd "$(git rev-parse --show-toplevel)" 2>/dev/null || cd "$(dirname "$0")/.."
 
 # `awk` walks each .rs file under src/, tracks the most-recent

--- a/scripts/extract_complexity_classes.sh
+++ b/scripts/extract_complexity_classes.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Extract the (type → ComplexityClass) pairs declared via the
+# `impl Complexity for ...` blocks across the crate. Output is one
+# line per impl, sorted, of the form:
+#
+#     crate::path::Type    ComplexityClass::Variant
+#
+# Used by the CI `complexity-baseline` regression-guard job in
+# `.github/workflows/ci.yml`. Drive direct as:
+#
+#     scripts/extract_complexity_classes.sh > .github/complexity-baseline.txt
+#
+# ADR-001 item #1 + phase-2 enforcement: this script turns the
+# type-level Complexity contract into a textual snapshot that CI
+# can diff between PRs. A silent downgrade (SubLinear → Linear etc.)
+# now fails the build the same way a regression in tests does.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)" 2>/dev/null || cd "$(dirname "$0")/.."
+
+# `awk` walks each .rs file under src/, tracks the most-recent
+# `impl Complexity for X { ... }` block, and emits a single line
+# per impl pairing the type with the right-hand side of `const CLASS`.
+#
+# Excludes the test-only `Dummy` type and inside `#[cfg(test)]` mods
+# (heuristic: skip lines under `mod tests`).
+
+find src -name '*.rs' -print0 |
+  xargs -0 awk '
+    /^[[:space:]]*#\[cfg\(test\)\]/ { in_test = NR + 1 }
+    /^mod tests \{/                 { in_mod_tests = 1 }
+    /^\}/ && in_mod_tests           { in_mod_tests = 0 }
+    in_mod_tests                    { next }
+
+    /^impl Complexity for/ {
+      # capture everything after "impl Complexity for " up to `{`
+      line = $0
+      sub(/^impl Complexity for /, "", line)
+      sub(/[[:space:]]*\{.*$/, "", line)
+      gsub(/[[:space:]]+/, " ", line)
+      type_name = line
+      next
+    }
+    /^[[:space:]]*const CLASS: ComplexityClass = / && type_name != "" {
+      rhs = $0
+      sub(/^[[:space:]]*const CLASS: ComplexityClass = /, "", rhs)
+      sub(/;.*$/, "", rhs)
+      # Adaptive { default, worst } may span lines; the common case is
+      # one-liner so we extract whatever ends at the semicolon on the
+      # same line. Multi-line variants are summarised as "Adaptive".
+      if (rhs ~ /^ComplexityClass::Adaptive/) rhs = "ComplexityClass::Adaptive"
+      printf "%-90s %s\n", type_name, rhs
+      type_name = ""
+    }
+  ' |
+  sort -u


### PR DESCRIPTION
## Summary

ADR-001 item #1 phase-2: the type-level Complexity contract is now enforceable across PRs. A reviewer accidentally dropping a public solver from SubLinear → Linear silently — historically impossible to catch in review — now fails CI the same way the safe-path security tests do.

## Mechanism

1. **`scripts/extract_complexity_classes.sh`** — awk-based extractor that walks `src/**/*.rs`, finds every `impl Complexity for X { ... }` block, and emits one sorted line per impl pairing the type with its `const CLASS` value. Skips test-only mods.

2. **`.github/complexity-baseline.txt`** — frozen snapshot:
   - `NeumannSolver` → `Linear`
   - `OptimizedConjugateGradientSolver` → `Linear`
   - `JLEmbedding` → `Linear`
   - `SublinearNeumannSolver` → `Adaptive`
   - `FindAnomalousRowsOp` → `Adaptive`
   - `IncrementalSolveOp` → `Adaptive`

3. **`complexity-baseline-guard` CI job** — regenerates the snapshot on every PR and diffs against the checked-in baseline. Mismatch → CI error with the regen command inline.

## Verified locally

- Generated baseline equals the extractor output (no-op diff on a clean checkout).
- Forcing the baseline to claim `Polynomial` instead of `Linear` correctly fails the diff (smoke test).

## Together with v1.7.1

Phase-2 work has now landed both sides of the Complexity contract:

- **Server-side budget enforcement** (v1.7.1): callers refused at MCP dispatch time if `max_complexity_class < method's worst case`.
- **Type-level baseline guard** (this PR): authors refused at CI time if a `Complexity` impl downgrades silently.

🤖 Driven by `/loop 5m` cron `a3644c7d`. PR #23.