### PR TITLE
feat(contrastive): find_anomalous_rows_in_subset — ADR-001 #6 phase-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.7.2] / Rust crate 0.3.2 — 2026-05-18
+
+ADR-001 phase-2 release. Three enforcement mechanisms now live, plus the sub-linear contrastive primitive that completes roadmap item #6's phase-2 plan.
+
+### Added
+
+- **`find_anomalous_rows_in_subset(baseline, current, candidates, k)`** in `src/contrastive.rs`. Drops the phase-1 `O(n log k)` full scan to `O(|candidates| log k)` by limiting the scan to a caller-supplied candidate set. Combined with the existing `SublinearNeumannSolver`'s single-entry primitive (`O(log n)` per query), the total contrastive top-k cost becomes `O(|candidates| · log n)` — true sub-linear in n when |candidates| ≪ n. RuView / Cognitum / Ruflo callers compute the candidate set from a sparse RHS delta's reachable rows, then invoke this function on the top-k boundary check.
+
+- **CI `complexity-baseline-guard` job** (`.github/workflows/ci.yml`) + `scripts/extract_complexity_classes.sh` + frozen `.github/complexity-baseline.txt`. Diffs the live `Complexity` impls against a checked-in snapshot on every PR; a silent class downgrade fails the build the same way safe-path regressions do. Uses `LC_ALL=C` so the sort is byte-stable across hosts.
+
+### Improved
+
+- **Phase-2 enforcement matrix now complete for ADR-001:**
+  - **Server-side budget rejection** (v1.7.1): MCP refuses over-budget solver invocations at dispatch time.
+  - **Type-level baseline guard** (this release): CI refuses `Complexity` impls that silently degrade.
+  - **Sub-linear contrastive primitive** (this release): `find_anomalous_rows_in_subset` lets callers pay only for the rows they care about.
+
+### Tests
+
+- 5 new unit tests in `src/contrastive.rs` pinning the new function's contract (out-of-set anomalies stay ignored, OOB indices silently skipped, full-set candidates equals phase-1 output, k limit, empty-candidates → empty result).
+- Total: **165 lib pass** (160 → +5), 11 doc pass, **7 CI gates** on every PR (test×2 OS, fmt+clippy, safe-path, bench-smoke, joules smoke, complexity-baseline-guard).
+
+[1.7.2]: https://github.com/ruvnet/sublinear-time-solver/releases/tag/v1.7.2
+
 ## [1.7.1] / Rust crate 0.3.1 — 2026-05-18
 
 Closes the ADR-001 roadmap. With this release the package is functionally SOTA per the ADR's own criterion (6 of 6 roadmap items shipped; README cites complexity classes as a first-class API surface; only CI J/solve integration remains, blocked on GH Actions exposing power counters).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sublinear"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["rUv <github.com/ruvnet>"]
 license = "MIT OR Apache-2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sublinear-time-solver",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "The Ultimate Mathematical & AI Toolkit: Sublinear algorithms, consciousness exploration, psycho-symbolic reasoning, chaos analysis, and temporal prediction in one unified MCP interface. WASM-accelerated with Lyapunov exponents and attractor dynamics.",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/contrastive.rs
+++ b/src/contrastive.rs
@@ -146,6 +146,91 @@ pub fn find_anomalous_rows(
     out
 }
 
+/// Top-k variant constrained to a caller-supplied **candidate set**. Skips
+/// the rest of the solution vector entirely.
+///
+/// This is the building block for the genuinely sub-linear contrastive
+/// recipe outlined in [ADR-001 §Roadmap item #6 phase-2]. The caller
+/// computes the candidate set once — typically the rows reachable from
+/// the support of a sparse RHS delta in a few hops of `A` — and passes
+/// it here. Cost is `O(|candidates| log k)` instead of `O(n log k)`,
+/// so when `|candidates| ≪ n` the call drops to true sub-linear in n.
+///
+/// Composes with `incremental::SparseDelta` and a per-entry solver like
+/// `SublinearNeumannSolver`:
+///
+/// ```text
+///   1. candidates = closure(delta.indices, A, depth)
+///   2. current[i] = sublinear_neumann.solve_single_entry(A, b_new, i)
+///                                                 for i in candidates
+///   3. top_k    = find_anomalous_rows_in_subset(baseline, current,
+///                                                candidates, k)
+/// ```
+///
+/// `current` must be a length-`n` vector that has the correct values at
+/// the candidate indices; entries at non-candidate indices are ignored.
+/// (We don't require sparsity — callers can pass a dense vector with
+/// stale values everywhere except the candidates.)
+///
+/// Result is sorted by descending anomaly score; ties broken by row
+/// index ascending. Returns an empty vec if `k == 0` or `candidates` is
+/// empty. Panics on `baseline.len() != current.len()`.
+pub fn find_anomalous_rows_in_subset(
+    baseline: &[Precision],
+    current: &[Precision],
+    candidates: &[usize],
+    k: usize,
+) -> Vec<AnomalyRow> {
+    assert_eq!(
+        baseline.len(),
+        current.len(),
+        "find_anomalous_rows_in_subset: dim mismatch {} vs {}",
+        baseline.len(),
+        current.len(),
+    );
+
+    if k == 0 || candidates.is_empty() || baseline.is_empty() {
+        return Vec::new();
+    }
+
+    let mut heap: BinaryHeap<MinHeapEntry> =
+        BinaryHeap::with_capacity(k.min(candidates.len()) + 1);
+
+    for &row in candidates {
+        // Skip out-of-bounds indices silently — caller may supply a
+        // closure that overshoots the matrix dimension (e.g. via a
+        // wrap-around graph traversal). Treating it as a no-op is more
+        // useful than panicking.
+        if row >= baseline.len() {
+            continue;
+        }
+        let anomaly = (current[row] - baseline[row]).abs();
+        let entry = MinHeapEntry(AnomalyRow {
+            row,
+            baseline: baseline[row],
+            current: current[row],
+            anomaly,
+        });
+        if heap.len() < k {
+            heap.push(entry);
+        } else if let Some(smallest) = heap.peek() {
+            if anomaly > smallest.0.anomaly {
+                heap.pop();
+                heap.push(entry);
+            }
+        }
+    }
+
+    let mut out: Vec<AnomalyRow> = heap.into_iter().map(|e| e.0).collect();
+    out.sort_by(|a, b| {
+        b.anomaly
+            .partial_cmp(&a.anomaly)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.row.cmp(&b.row))
+    });
+    out
+}
+
 /// Return only the rows whose anomaly score exceeds `threshold`. Useful as
 /// the boundary-crossing primitive for change-driven activation: an agent
 /// stays asleep until at least one entry crosses the threshold.
@@ -295,5 +380,80 @@ mod tests {
         let c = alloc::vec![0.01, 0.02, 0.03, 0.04, 0.05];
         let above = find_rows_above_threshold(&b, &c, 1.0);
         assert!(above.is_empty(), "no entry above threshold should return empty");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // find_anomalous_rows_in_subset (ADR-001 #6 phase-2)
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn subset_returns_only_candidates() {
+        let baseline = alloc::vec![0.0; 10];
+        let mut current = alloc::vec![0.0; 10];
+        // Put a huge anomaly at row 7 that ISN'T in the candidate set —
+        // we expect it to be ignored.
+        current[7] = 999.0;
+        // Real candidates with smaller anomalies.
+        current[2] = 5.0;
+        current[5] = 3.0;
+        let candidates = alloc::vec![2usize, 5];
+        let top = find_anomalous_rows_in_subset(&baseline, &current, &candidates, 5);
+        assert_eq!(top.len(), 2);
+        assert_eq!(top[0].row, 2);
+        assert_eq!(top[0].anomaly, 5.0);
+        assert_eq!(top[1].row, 5);
+        assert_eq!(top[1].anomaly, 3.0);
+        // 999.0 at row 7 is OUTSIDE the candidates — must not appear.
+        assert!(top.iter().all(|r| r.row != 7));
+    }
+
+    #[test]
+    fn subset_k_limit_works() {
+        let baseline = alloc::vec![0.0; 100];
+        let mut current = alloc::vec![0.0; 100];
+        for &i in &[10, 20, 30, 40, 50] {
+            current[i] = i as Precision;
+        }
+        let candidates = alloc::vec![10usize, 20, 30, 40, 50];
+        // Ask for top-3; should get the 3 biggest anomalies (rows 50, 40, 30).
+        let top = find_anomalous_rows_in_subset(&baseline, &current, &candidates, 3);
+        assert_eq!(top.len(), 3);
+        assert_eq!(top[0].row, 50);
+        assert_eq!(top[1].row, 40);
+        assert_eq!(top[2].row, 30);
+    }
+
+    #[test]
+    fn subset_ignores_out_of_bounds_indices() {
+        let baseline = alloc::vec![0.0; 5];
+        let mut current = alloc::vec![0.0; 5];
+        current[2] = 10.0;
+        // Caller's candidate closure overshoots — out-of-bound indices
+        // must be skipped silently, not panic.
+        let candidates = alloc::vec![2usize, 100, 200];
+        let top = find_anomalous_rows_in_subset(&baseline, &current, &candidates, 5);
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].row, 2);
+    }
+
+    #[test]
+    fn subset_empty_candidates_returns_empty() {
+        let baseline = alloc::vec![0.0; 5];
+        let current = alloc::vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let candidates: Vec<usize> = alloc::vec![];
+        let top = find_anomalous_rows_in_subset(&baseline, &current, &candidates, 10);
+        assert!(top.is_empty());
+    }
+
+    #[test]
+    fn subset_matches_full_scan_when_candidates_cover_all_rows() {
+        // Sanity check: when the candidate set IS the full row range,
+        // the result should match find_anomalous_rows.
+        let baseline = alloc::vec![0.0; 8];
+        let current = alloc::vec![1.0, 5.0, 1.0, 9.0, 2.0, 7.0, 3.0, 6.0];
+        let full = find_anomalous_rows(&baseline, &current, 4);
+        let candidates: Vec<usize> = (0..8).collect();
+        let subset = find_anomalous_rows_in_subset(&baseline, &current, &candidates, 4);
+        assert_eq!(full, subset);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,9 @@ pub use incremental::{IncrementalSolver, SparseDelta, IncrementalConfig};
 // for change-driven activation: which rows of the current solution diverged
 // most from baseline? Backbone of RuView / Cognitum wake-on-event.
 pub mod contrastive;
-pub use contrastive::{find_anomalous_rows, find_rows_above_threshold, AnomalyRow};
+pub use contrastive::{
+    find_anomalous_rows, find_anomalous_rows_in_subset, find_rows_above_threshold, AnomalyRow,
+};
 
 // Sublinear algorithms with mathematically rigorous O(log n) complexity
 pub mod sublinear;


### PR DESCRIPTION
## Summary

Phase-2 work on ADR-001 roadmap item #6. The phase-1 `find_anomalous_rows` does an `O(n log k)` full scan; this PR adds the building block that lifts that to **`O(|candidates| log k)`** when the caller supplies a candidate set.

When `|candidates| ≪ n` — which is the case for sparse-delta-driven activation in RuView / Cognitum / Ruflo's inner loops — the call becomes true sub-linear in n. Combined with the sublinear-Neumann single-entry primitive's `O(log n)` per query, the **total contrastive top-k cost is `O(|candidates| · log n)`**, matching the §Roadmap promise.

## Compositional recipe

```text
1. candidates = closure(delta.indices, A, depth)
2. current[i] = sublinear_neumann.solve_single_entry(A, b_new, i)
                                        for i in candidates
3. top_k    = find_anomalous_rows_in_subset(baseline, current,
                                            candidates, k)
```

Step 1 is the caller's domain knowledge (which rows are reachable from a sparse RHS delta). Step 2 is the existing `SublinearNeumannSolver`. Step 3 is the new function in this PR.

## Tests (5 new)

- `subset_returns_only_candidates` — out-of-set anomalies stay ignored (the architectural payoff).
- `subset_k_limit_works` — k bound respected.
- `subset_ignores_out_of_bounds_indices` — caller's closure can overshoot the matrix dim without panicking.
- `subset_empty_candidates_returns_empty`.
- `subset_matches_full_scan_when_candidates_cover_all_rows` — consistency sanity vs phase-1.

Full lib test count: **165 pass** (was 160 — +5). Doc tests unchanged. Complexity baseline unchanged (this is a function, not a new operator type).

## ADR-001 phase-2 status

- ✅ Server-side `max_complexity_class` budget rejection (v1.7.1)
- ✅ Type-level baseline regression guard (CI; PR #23 merged)
- ✅ **Contrastive sub-linear primitive** (this PR)
- Remaining: hwmon power backend (Pi Zero), self-hosted RAPL runner — both infrastructure, not code.

🤖 Driven by `/loop 5m` cron `a3644c7d`. PR #24.