### PR TITLE
feat(adr-001 #4): expand estimateComplexityClass table for phase-2 primitives

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1378,6 +1378,41 @@ export class SublinearSolverMCPServer {
         detail: 'O(log n) per single-entry query on DD systems via JL + recursive Neumann; O(n) base case at n ≤ base_case_threshold.',
         edgeSafe: true,
       },
+      // ── ADR-001 #6 phase-2A primitives ────────────────────────────
+      'closure-indices': {
+        class: 'SubLinear',
+        detail: 'Bounded-depth BFS through A.row_iter starting from a sparse seed set. O(depth · branch · |closure|); SubLinear when depth · branch ≪ n. Widens to Linear at full diameter.',
+        edgeSafe: true,
+      },
+      'contrastive-solve-on-change': {
+        class: 'Adaptive',
+        default: 'Linear',
+        worst: 'Linear',
+        detail: 'Phase-2A orchestrator: closure (SubLinear) + warm-start solve_on_change (Linear) + top-k-in-subset (SubLinear). Bounded by the inner solve. Use `contrastive-solve-on-change-sublinear` for end-to-end SubLinear.',
+        edgeSafe: false,
+      },
+      // ── ADR-001 #6 phase-2B primitives ────────────────────────────
+      'solve-single-entry-neumann': {
+        class: 'SubLinear',
+        detail: 'Truncated Neumann restricted to closure(target, max_terms). Returns x[i] = e_iᵀ A⁻¹ b without materialising x. O(max_terms · |closure| · branch); SubLinear in n for sparse DD + bounded depth.',
+        edgeSafe: true,
+      },
+      'contrastive-solve-on-change-sublinear': {
+        class: 'SubLinear',
+        detail: 'Phase-2B orchestrator: closure (SubLinear) + per-entry sublinear-Neumann at each closure index (SubLinear) + top-k-in-subset (SubLinear). End-to-end SubLinear in n.',
+        edgeSafe: true,
+      },
+      // ── ADR-001 #2 phase-2 ────────────────────────────────────────
+      'solve-on-change': {
+        class: 'Linear',
+        detail: 'Warm-started full solve with prev_solution as initial_guess. O(k_warm · nnz(A)) per call; k_warm ≪ k_cold for small deltas. Returns the full n-vector solution.',
+        edgeSafe: false,
+      },
+      'solve-on-change-sublinear': {
+        class: 'SubLinear',
+        detail: 'Closure (SubLinear) + per-entry sublinear-Neumann at each closure index (SubLinear). Returns Vec<(idx, val)> over the closure only — never materialises the full n-vector. End-to-end SubLinear in n.',
+        edgeSafe: true,
+      },
     };
 
     const entry = table[method];


### PR DESCRIPTION
## Summary

\`handleEstimateComplexityClass\` had a hardcoded table that only covered the v1.7.0 / 0.3.0 baseline methods. The phase-2 primitives shipped in #26 / #27 / #29 weren't queryable — agents calling \`estimateComplexityClass\` with \`method='solve-on-change-sublinear'\` got *"Unknown method"* instead of *"SubLinear"*. This lands the missing rows.

## New table entries

| Method | Class | Edge-safe? |
|---|---|---|
| \`closure-indices\` | SubLinear | yes |
| \`contrastive-solve-on-change\` | Linear (Adaptive worst) | no |
| \`contrastive-solve-on-change-sublinear\` | SubLinear | yes |
| \`solve-single-entry-neumann\` | SubLinear | yes |
| \`solve-on-change\` | Linear | no |
| \`solve-on-change-sublinear\` | SubLinear | yes |

Each entry's \`detail\` string mirrors the Rust \`Complexity::DETAIL\` on its corresponding Op marker (\`ClosureIndicesOp\`, \`SolveOnChangeSublinearOp\`, etc) so the wire contract and the Rust contract stay synced.

## Test plan

- [x] \`npm run build\` clean (TS compiles)
- [ ] Full CI

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)