### PR TITLE
feat(adr-001 #3): adaptive Neumann depth from coherence + tolerance

### DIFF
--- a/examples/event_driven_anomaly.rs
+++ b/examples/event_driven_anomaly.rs
@@ -42,8 +42,9 @@
 
 use std::time::Instant;
 use sublinear_solver::{
-    contrastive_solve_on_change_sublinear, delta_below_solve_threshold, solve_on_change_sublinear,
-    AnomalyRow, Matrix, NeumannSolver, SolverAlgorithm, SolverOptions, SparseDelta, SparseMatrix,
+    contrastive_solve_on_change_sublinear, delta_below_solve_threshold, optimal_neumann_terms,
+    solve_on_change_sublinear, AnomalyRow, Matrix, NeumannSolver, SolverAlgorithm, SolverOptions,
+    SparseDelta, SparseMatrix,
 };
 use sublinear_solver::coherence::coherence_score;
 
@@ -99,8 +100,14 @@ fn main() {
         .map(|i| matrix.get(i, i).unwrap_or(0.0).abs())
         .filter(|x| *x > 0.0)
         .fold(f64::INFINITY, |a, b| if a < b { a } else { b });
+    // ── Adaptive Neumann-term selection (PR #37): pick max_terms from
+    //    the coherence + tolerance bound instead of guessing. ──
+    let b_inf = b_prev.iter().map(|x| x.abs()).fold(0.0_f64, f64::max);
+    let auto_terms =
+        optimal_neumann_terms(coherence, b_inf, min_diag, 1e-8).unwrap_or(32);
     println!(
-        "gate cache:   coherence={coherence:.3}, min_diag={min_diag:.3} (skip-threshold = 1e-6)\n"
+        "gate cache:   coherence={coherence:.3}, min_diag={min_diag:.3}, \
+         auto_terms={auto_terms} (skip=1e-6, tol=1e-8)\n"
     );
 
     // ── Event stream. Each entry is (event_label, sensor_index, delta_value).
@@ -123,7 +130,8 @@ fn main() {
     println!("{}", "─".repeat(74));
 
     let closure_depth = 4usize;
-    let max_terms = 24usize;
+    // `max_terms` is now auto-tuned per matrix via the adaptive helper.
+    let max_terms = auto_terms;
     let tolerance = 1e-8_f64;
     let skip_threshold = 1.0e-6_f64;
     let top_k = 3usize;

--- a/src/coherence.rs
+++ b/src/coherence.rs
@@ -189,6 +189,98 @@ pub fn delta_below_solve_threshold(
     bound < tolerance
 }
 
+/// Minimum number of Neumann terms required to hit `tolerance` on a
+/// single-entry solve, given the matrix's `coherence` margin and the
+/// magnitudes of the RHS and any perturbation.
+///
+/// ## Math
+///
+/// For strictly DD `A = D - O` with coherence `c`, the Neumann series
+/// `A⁻¹ b = Σ_k y_k` satisfies `‖y_k‖_∞ ≤ ρ^k · ‖y_0‖_∞` where the
+/// spectral radius of `D⁻¹O` is bounded by `ρ ≤ 1 - c`. To get
+/// per-entry error below `tolerance` we need
+///
+/// ```text
+///   k ≥ log(‖y_0‖_∞ / tolerance) / log(1 / ρ)
+///       = log(‖b‖_∞ / (min_diag · tolerance)) / log(1 / (1 - c))
+/// ```
+///
+/// This function picks the smallest such `k` (rounded up). Saturates at
+/// `64` so a callers-provided pathological pair can't blow up the
+/// iteration count.
+///
+/// ## Returns
+///
+/// - `Some(k)` — recommended Neumann term count, clamped to `[1, 64]`.
+/// - `None` — non-strict-DD input (`coherence <= 0`), or non-positive
+///   `tolerance`, or non-positive `min_diag`. Caller should fall back
+///   to a hand-picked `max_terms` or to a full solve.
+///
+/// ## Edge cases
+///
+/// - `b_inf_norm == 0` → returns `Some(1)` (we still want at least one
+///   term to confirm the zero answer).
+/// - Inputs that produce `k > 64` are clamped (the bound is conservative;
+///   real matrices rarely need that many).
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # use sublinear_solver::coherence::optimal_neumann_terms;
+/// // For coherence 0.5, ‖b‖ = 10, min_diag = 5, tolerance = 1e-8:
+/// //   k ≥ log(10 / (5 · 1e-8)) / log(2) = log2(2e8) ≈ 27.6 → k = 28
+/// let k = optimal_neumann_terms(
+///     /*coherence=*/ 0.5,
+///     /*b_inf_norm=*/ 10.0,
+///     /*min_diag=*/   5.0,
+///     /*tolerance=*/  1e-8,
+/// ).unwrap();
+/// assert!(k >= 28 && k <= 30);
+/// ```
+pub fn optimal_neumann_terms(
+    coherence: Precision,
+    b_inf_norm: Precision,
+    min_diag: Precision,
+    tolerance: Precision,
+) -> Option<usize> {
+    if !coherence.is_finite() || coherence <= 0.0 || coherence >= 1.0 {
+        return None;
+    }
+    if !min_diag.is_finite() || min_diag <= 0.0 {
+        return None;
+    }
+    if !tolerance.is_finite() || tolerance <= 0.0 {
+        return None;
+    }
+    if b_inf_norm < 0.0 || !b_inf_norm.is_finite() {
+        return None;
+    }
+    // Zero RHS → one term is enough (it's the zero answer).
+    if b_inf_norm == 0.0 {
+        return Some(1);
+    }
+    // ρ ≤ 1 - coherence is the conservative spectral-radius bound.
+    let rho = 1.0 - coherence;
+    // 1/ρ > 1 because coherence > 0 ⇒ rho < 1.
+    let one_over_rho_log = (1.0 / rho).ln();
+    if !one_over_rho_log.is_finite() || one_over_rho_log <= 0.0 {
+        // Numerical floor — extreme coherence near 1.0 collapses the log.
+        return Some(1);
+    }
+    let y0 = b_inf_norm / min_diag; // ‖D⁻¹ b‖_∞ upper bound
+    let ratio = y0 / tolerance;
+    if ratio <= 1.0 {
+        // Already at tolerance from term 0 alone.
+        return Some(1);
+    }
+    let k_float = ratio.ln() / one_over_rho_log;
+    if !k_float.is_finite() || k_float <= 0.0 {
+        return Some(1);
+    }
+    let k = k_float.ceil() as usize;
+    Some(k.clamp(1, 64))
+}
+
 /// Verify that a matrix's coherence meets or exceeds the configured
 /// threshold; otherwise return `SolverError::Incoherent`.
 ///
@@ -384,5 +476,63 @@ mod tests {
     fn delta_below_threshold_on_empty_delta_skips() {
         // Empty delta has inf-norm 0, which is below any positive tolerance.
         assert!(delta_below_solve_threshold(0.8, 5.0, &[], 1e-8));
+    }
+
+    // ── optimal_neumann_terms tests ────────────────────────────────────
+
+    #[test]
+    fn optimal_terms_basic_case() {
+        // coherence=0.5, ‖b‖=10, min_diag=5, tol=1e-8.
+        // y0 = 2, ratio = 2 / 1e-8 = 2e8, log2(2e8) ≈ 27.6 → 28
+        // rho = 0.5, log(2) ≈ 0.693, log(2e8) ≈ 19.11
+        // k ≥ 19.11 / 0.693 ≈ 27.6 → 28
+        let k = optimal_neumann_terms(0.5, 10.0, 5.0, 1e-8).unwrap();
+        assert!(k >= 27 && k <= 29, "expected ~28, got {k}");
+    }
+
+    #[test]
+    fn optimal_terms_high_coherence_needs_few_terms() {
+        // coherence near 1: 1/rho is huge, log is huge, so k is tiny.
+        let k = optimal_neumann_terms(0.95, 10.0, 5.0, 1e-6).unwrap();
+        assert!(k <= 10, "high coherence should converge fast; got {k}");
+    }
+
+    #[test]
+    fn optimal_terms_low_coherence_needs_many_terms() {
+        // coherence near 0: 1/rho ≈ 1, log near 0, so k saturates.
+        let k = optimal_neumann_terms(0.01, 10.0, 5.0, 1e-6).unwrap();
+        assert_eq!(k, 64, "tiny coherence should saturate at the cap; got {k}");
+    }
+
+    #[test]
+    fn optimal_terms_rejects_non_dd() {
+        assert!(optimal_neumann_terms(0.0, 1.0, 1.0, 1e-6).is_none());
+        assert!(optimal_neumann_terms(-0.1, 1.0, 1.0, 1e-6).is_none());
+        assert!(optimal_neumann_terms(1.0, 1.0, 1.0, 1e-6).is_none());
+        assert!(optimal_neumann_terms(1.5, 1.0, 1.0, 1e-6).is_none());
+    }
+
+    #[test]
+    fn optimal_terms_rejects_bad_min_diag() {
+        assert!(optimal_neumann_terms(0.5, 1.0, 0.0, 1e-6).is_none());
+        assert!(optimal_neumann_terms(0.5, 1.0, -1.0, 1e-6).is_none());
+    }
+
+    #[test]
+    fn optimal_terms_rejects_bad_tolerance() {
+        assert!(optimal_neumann_terms(0.5, 1.0, 1.0, 0.0).is_none());
+        assert!(optimal_neumann_terms(0.5, 1.0, 1.0, -1e-6).is_none());
+    }
+
+    #[test]
+    fn optimal_terms_zero_b_returns_one() {
+        // Zero RHS — one term confirms the zero answer.
+        assert_eq!(optimal_neumann_terms(0.5, 0.0, 1.0, 1e-8).unwrap(), 1);
+    }
+
+    #[test]
+    fn optimal_terms_loose_tolerance_returns_one() {
+        // y0 = 2, tolerance = 10 → ratio < 1, no iteration needed beyond term 0.
+        assert_eq!(optimal_neumann_terms(0.5, 10.0, 5.0, 10.0).unwrap(), 1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub use incremental::{
     solve_on_change_sublinear, IncrementalConfig, IncrementalSolver, SolveOnChangeSublinearOp,
     SparseDelta,
 };
-pub use coherence::{delta_below_solve_threshold, delta_inf_bound};
+pub use coherence::{delta_below_solve_threshold, delta_inf_bound, optimal_neumann_terms};
 
 // Contrastive search (ADR-001 roadmap item #6). Boundary-crossing primitive
 // for change-driven activation: which rows of the current solution diverged


### PR DESCRIPTION
## Summary

Today callers of \`solve_on_change_sublinear\` / \`solve_single_entry_neumann\` pick \`max_terms\` blindly. The closure size scales with depth, so an over-pick wastes work; an under-pick silently misses the tolerance bound. This PR lands the math-driven helper:

\`\`\`rust
optimal_neumann_terms(coherence, b_inf_norm, min_diag, tolerance) -> Option<usize>
\`\`\`

For strict-DD \`A = D - O\` with coherence \`c\`, the Neumann series satisfies \`‖y_k‖ ≤ ρ^k · ‖y_0‖\` with \`ρ ≤ 1 - c\`. To hit tolerance:

\`\`\`
k ≥ log(‖b‖_∞ / (min_diag · tolerance)) / log(1 / (1 - c))
\`\`\`

Returned \`k\` is clamped to \`[1, 64]\` (caller-protective floor + cap).

## Composition

- Cache \`(coherence, min_diag)\` once at matrix-build time.
- For each event, compute \`auto_terms = optimal_neumann_terms(...)\` instead of guessing.
- Pass \`auto_terms\` as \`max_terms\` to \`solve_on_change_sublinear\`.

## Example update

The event-driven example (PR #33, #35) now picks \`max_terms\` adaptively from the matrix's coherence at startup, removing the last hand-tuned magic number from the canonical inner loop.

Discovery: the prior hand-picked \`max_terms=24\` was **under-tuned** for the test matrix's coherence (0.2). The math-driven helper picks 64 (clamped) for the same tolerance. Per-event latency goes from ~2 ms to ~12 ms — that's *correctness paying its real cost*. Higher-coherence matrices (≥ 0.5) would pick lower term counts, pulling the bench crossover lower.

## Test plan

- [x] 8 new \`coherence::optimal_terms_*\` tests covering high/low coherence, edge cases, rejection paths
- [x] 31/31 coherence tests pass
- [x] \`cargo run --release --example event_driven_anomaly\` runs end-to-end
- [ ] Full CI

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)